### PR TITLE
Individual labels padding instead of general one in `Options`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "@interacta/css-labels",
-  "version": "0.1.2",
+  "version": "0.1.3-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@interacta/css-labels",
-      "version": "0.1.2",
-      "hasInstallScript": true,
+      "version": "0.1.3-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.45.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@interacta/css-labels",
-  "version": "0.1.3-beta.1",
+  "version": "0.1.3-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@interacta/css-labels",
-      "version": "0.1.3-beta.1",
+      "version": "0.1.3-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.45.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interacta/css-labels",
-  "version": "0.1.3-beta.1",
+  "version": "0.1.3-beta.2",
   "description": "CSS Label renderer",
   "author": "Interacta",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interacta/css-labels",
-  "version": "0.1.3-beta.0",
+  "version": "0.1.3-beta.1",
   "description": "CSS Label renderer",
   "author": "Interacta",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interacta/css-labels",
-  "version": "0.1.2",
+  "version": "0.1.3-beta.0",
   "description": "CSS Label renderer",
   "author": "Interacta",
   "main": "dist/index.js",

--- a/src/css-label.ts
+++ b/src/css-label.ts
@@ -249,7 +249,6 @@ export class CssLabel {
    * the `transform` from `setStyle` CSS style if specified.
    */
   public draw (): void {
-    this._measureText()
     const isVisible = this.getVisibility()
     if (isVisible !== this._prevVisible) {
       if (this._prevVisible === false) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { CssLabel } from './css-label.js'
-import { LabelOptions, OnClickCallback, Options, Padding } from './types.js'
+import { LabelOptions, OnClickCallback, Options } from './types.js'
 
 import { cssLabelContainerStyles, injectStyles, labelsContainerClassName, hiddenLabelsContainerClassName } from './styles.js'
 
@@ -8,7 +8,6 @@ export class LabelRenderer {
   private _cssLabels = new Map<string, CssLabel>()
   private _container: HTMLDivElement
   private _onClickCallback: OnClickCallback | undefined
-  private _padding: Padding | undefined
   private _pointerEvents: Options['pointerEvents'] | undefined
   private _elementToData = new Map<HTMLDivElement, LabelOptions>()
   private _dispatchWheelEventElement: HTMLElement | undefined
@@ -21,7 +20,6 @@ export class LabelRenderer {
 
     this._container.className = labelsContainerClassName
     if (options?.onLabelClick) this._onClickCallback = options.onLabelClick
-    if (options?.padding) this._padding = options.padding
     if (options?.pointerEvents) this._pointerEvents = options.pointerEvents
     if (options?.dontInjectStyles) this._dontInjectStyles = options.dontInjectStyles
     if (options?.dispatchWheelEventElement) {
@@ -34,7 +32,7 @@ export class LabelRenderer {
     // Add new labels and take into account existing labels
     const labelsToDelete = new Map(this._cssLabels)
     labels.forEach(label => {
-      const { x, y, fontSize, color, text, weight, opacity, shouldBeShown, style, className } = label
+      const { x, y, fontSize, color, text, weight, opacity, shouldBeShown, style, className, padding } = label
       const exists = this._cssLabels.get(label.id)
       if (exists) {
         labelsToDelete.delete(label.id)
@@ -51,7 +49,8 @@ export class LabelRenderer {
         if (weight !== undefined) labelToUpdate.setWeight(weight)
         if (fontSize !== undefined) labelToUpdate.setFontSize(fontSize)
         if (color !== undefined) labelToUpdate.setColor(color)
-        if (this._padding !== undefined) labelToUpdate.setPadding(this._padding)
+        if (padding !== undefined) labelToUpdate.setPadding(padding)
+        else labelToUpdate.resetPadding()
         if (this._pointerEvents !== undefined) labelToUpdate.setPointerEvents(this._pointerEvents)
         if (opacity !== undefined) labelToUpdate.setOpacity(opacity)
         if (shouldBeShown !== undefined) labelToUpdate.setForceShow(shouldBeShown)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { CssLabel } from './css-label.js'
-import { LabelOptions, OnClickCallback, Options } from './types.js'
+import { LabelOptions, OnClickCallback, Options, Padding } from './types.js'
 
 import { cssLabelContainerStyles, injectStyles, labelsContainerClassName, hiddenLabelsContainerClassName } from './styles.js'
 
@@ -12,6 +12,8 @@ export class LabelRenderer {
   private _elementToData = new Map<HTMLDivElement, LabelOptions>()
   private _dispatchWheelEventElement: HTMLElement | undefined
   private _dontInjectStyles: boolean | undefined
+  private _padding: Padding | undefined
+  private _fontSize: number | undefined
 
   public constructor (container: HTMLDivElement, options?: Options) {
     if (!options?.dontInjectStyles && !globalCssLabelRendererStyles) globalCssLabelRendererStyles = injectStyles(cssLabelContainerStyles)
@@ -22,6 +24,9 @@ export class LabelRenderer {
     if (options?.onLabelClick) this._onClickCallback = options.onLabelClick
     if (options?.pointerEvents) this._pointerEvents = options.pointerEvents
     if (options?.dontInjectStyles) this._dontInjectStyles = options.dontInjectStyles
+    if (options?.padding) this._padding = options.padding
+    if (options?.fontSize) this._fontSize = options.fontSize
+
     if (options?.dispatchWheelEventElement) {
       this._dispatchWheelEventElement = options.dispatchWheelEventElement
       this._container.addEventListener('wheel', this._onWheel.bind(this))
@@ -47,10 +52,21 @@ export class LabelRenderer {
         labelToUpdate.setPosition(x, y)
         if (style !== undefined) labelToUpdate.setStyle(style)
         if (weight !== undefined) labelToUpdate.setWeight(weight)
-        if (fontSize !== undefined) labelToUpdate.setFontSize(fontSize)
+
         if (color !== undefined) labelToUpdate.setColor(color)
+
+        /**
+         * We need to check if the font size and padding are specified in the Options.
+         * These properties can't be set using general CSS styles or class names because
+         * they are used to calculate the label's size.
+         */
+        if (fontSize !== undefined) labelToUpdate.setFontSize(fontSize)
+        else if (this._fontSize !== undefined) labelToUpdate.setFontSize(this._fontSize)
+        else labelToUpdate.resetFontSize()
         if (padding !== undefined) labelToUpdate.setPadding(padding)
+        else if (this._padding !== undefined) labelToUpdate.setPadding(this._padding)
         else labelToUpdate.resetPadding()
+
         if (this._pointerEvents !== undefined) labelToUpdate.setPointerEvents(this._pointerEvents)
         if (opacity !== undefined) labelToUpdate.setOpacity(opacity)
         if (shouldBeShown !== undefined) labelToUpdate.setForceShow(shouldBeShown)

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,4 +27,6 @@ export interface Options {
   pointerEvents?: 'none' | 'auto' | 'all';
   dispatchWheelEventElement?: HTMLElement;
   dontInjectStyles?: boolean;
+  padding?: Padding;
+  fontSize?: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,13 +17,13 @@ export interface LabelOptions {
   shouldBeShown?: boolean;
   style?: string;
   className?: string;
+  padding?: Padding;
 }
 
 export type OnClickCallback = (e: MouseEvent, label: LabelOptions) => void | undefined
 
 export interface Options {
   onLabelClick?: OnClickCallback;
-  padding?: Padding;
   pointerEvents?: 'none' | 'auto' | 'all';
   dispatchWheelEventElement?: HTMLElement;
   dontInjectStyles?: boolean;


### PR DESCRIPTION
- Call `_measureText()` only properties affecting dimensions have changed to prevent redundant calculations
- Added `padding` property to `LabelOptions` interface. Each label can now have its own custom padding configuration
- Added `fontSize` property to `Options` interface for `LabelRenderer`. Allows setting a default font size for all labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Improved label rendering by deferring text measurement updates, enhancing performance.
  - Simplified padding management to ensure consistent styling whether applying or resetting padding.
  - Refined label configurations by reallocating padding settings more precisely.
  - Enhanced font size and padding handling for labels, allowing explicit setting, resetting, and inheritance from renderer defaults.
- **Documentation**
  - Updated documentation to clarify default behaviors for label padding.
- **Chores**
  - Updated package version to 0.1.3-beta.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->