### PR TITLE
Fix: hide empty and whitespace-only labels

### DIFF
--- a/src/css-label.ts
+++ b/src/css-label.ts
@@ -289,7 +289,7 @@ export class CssLabel {
   }
 
   public getVisibility (): boolean {
-    return this._visible
+    return this._visible && this._text.trim().length > 0
   }
 
   public isOnScreen (): boolean {


### PR DESCRIPTION
Labels with no text or only whitespace are no longer shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed label visibility behavior to exclude empty or whitespace-only content from appearing as visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->