### PR TITLE
Use previous visibility tie-breaker for overlaps

### DIFF
--- a/src/css-label.ts
+++ b/src/css-label.ts
@@ -363,6 +363,10 @@ export class CssLabel {
     return this._weight
   }
 
+  public getPrevVisible (): boolean {
+    return this._prevVisible
+  }
+
   /**
    * Gets the left edge of the label's bounding box.
    * @returns The x coordinate of the left edge.

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,7 @@ export class LabelRenderer {
     const containerWidth = this._container.offsetWidth
     const containerHeight = this._container.offsetHeight
 
+    // Set label visibility to true if they are on screen
     cssLabels.forEach(l => l.setVisibility(l.isOnScreen(containerWidth, containerHeight)))
 
     if (cssLabels.length <= 1) return
@@ -158,15 +159,20 @@ export class LabelRenderer {
         // No further x-overlap possible (sorted by left edge)
         if (label2.getLeft() > label1.getRight()) break
 
-        const isOverlapping = label1.overlaps(label2)
-        if (isOverlapping) {
-          if (label2.getWeight() > label1.getWeight()) {
-            label1.setVisibility(label2.getForceShow() ? false : label1.getForceShow())
-            if (!label1.getVisibility()) break // no further comparisons with this label
-          } else {
-            label2.setVisibility(label1.getForceShow() ? false : label2.getForceShow())
-          }
-        }
+        // Continue if the labels don't overlap
+        if (!label1.overlaps(label2)) continue
+
+        // Prefer: 1) higher weight, 2) previously visible (when equal weight and no forceShow)
+        const preferLabel2 = label2.getWeight() > label1.getWeight() ||
+          (label1.getWeight() === label2.getWeight() &&
+            !label1.getForceShow() && !label2.getForceShow() &&
+            label2.getPrevVisible() && !label1.getPrevVisible())
+
+        const [winner, loser] = preferLabel2 ? [label2, label1] : [label1, label2]
+        loser.setVisibility(winner.getForceShow() ? false : loser.getForceShow())
+
+        // No further comparisons with this label
+        if (!label1.getVisibility()) break
       }
     }
   }


### PR DESCRIPTION
When two overlapping labels have equal weight and neither is forced to show, the collision resolver now favors the label that was already visible (`prevVisible`) over one that was not. This prevents labels from flickering between frames when competing labels have the same priority.

### Changes
- Added `getPrevVisible()` getter to `CssLabel`
- Updated `_intersectLabels` to use `prevVisible` as a tiebreaker for equal-weight, non-forced labels

### Before

https://github.com/user-attachments/assets/0ba9db40-512c-4e88-a871-5e587cbe51cf


### After

https://github.com/user-attachments/assets/873e3171-1900-4d51-b131-2a9339273a3d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Redesigned label overlap resolution to use weight-based priority determination for resolving conflicts when labels overlap
  * Enhanced performance with pre-validation checks to ensure labels remain within screen boundaries before processing overlaps
  * Streamlined visibility handling logic to reduce unnecessary comparisons during overlap detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->